### PR TITLE
Tiles without extension

### DIFF
--- a/apps/gui/scaemv/Changelog
+++ b/apps/gui/scaemv/Changelog
@@ -1,2 +1,4 @@
+Version 0.1.1
+	Adds support for map tiles without file extensions. 
 Version 0.1.0
 	Release date: 2013.12.20

--- a/apps/gui/scaemv/descriptions/scaemv.rst
+++ b/apps/gui/scaemv/descriptions/scaemv.rst
@@ -634,7 +634,8 @@ should specify the way they are stored.
    # - %3 = line (0- 2^zoom-1 in Mercator projection)
    # Each parameter can be used more than once.
    # @note It is not mandatory to specify the extension of the file, the
-   #       algorithm will try and fetch PNG and JPG files
+   #       algorithm will try and fetch PNG and JPG files (with and without 
+   #       extension).
    map.tilePattern = "%1/%2/%3"
 
 More information about tiles 

--- a/apps/gui/scwev/descriptions/scwev.rst
+++ b/apps/gui/scwev/descriptions/scwev.rst
@@ -223,7 +223,8 @@ should specify the way they are stored.
    # - %3 = line (0- 2^zoom-1 in Mercator projection)
    # Each parameter can be used more than once.
    # @note It is not mandatory to specify the extension of the file, the
-   #       algorithm will try and fetch PNG and JPG files
+   #       algorithm will try and fetch PNG and JPG files (with and without 
+   #       extension).
    map.tilePattern = "%1/%2/%3"
 
 More information about tiles 

--- a/libs/ipgp/gui/map/tile.cpp
+++ b/libs/ipgp/gui/map/tile.cpp
@@ -96,10 +96,13 @@ const int& Tile::z() const {
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 const QString Tile::path() const {
 
+	const QString noext = _path + suffix();
 	const QString png = _path + suffix() + ".png";
 	const QString jpg = _path + suffix() + ".jpg";
 
-	if ( QFile::exists(png) )
+	if ( QFile::exists(noext) )
+		return noext;
+	else if ( QFile::exists(png) )
 		return png;
 	else
 		return jpg;


### PR DESCRIPTION
The mapprojection package stores tiles without extension. This change allow to use these tiles in the ipgp gui's.